### PR TITLE
fix: Lambda roles VPC policy security hotspot

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -277,6 +277,11 @@ Resources:
                   - ec2:CreateNetworkInterface
                   - ec2:DeleteNetworkInterface
                 Resource: '*'
+                Condition: {
+                  "StringEquals": {
+                    "aws:CalledViaLast": "lambda.amazonaws.com"
+                  }
+                }
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
@@ -382,6 +387,11 @@ Resources:
                   - ec2:CreateNetworkInterface
                   - ec2:DeleteNetworkInterface
                 Resource: '*'
+                Condition: {
+                  "StringEquals": {
+                    "aws:CalledViaLast": "lambda.amazonaws.com"
+                  }
+                }
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
@@ -484,6 +494,11 @@ Resources:
                   - ec2:CreateNetworkInterface
                   - ec2:DeleteNetworkInterface
                 Resource: '*'
+                Condition: {
+                  "StringEquals": {
+                    "aws:CalledViaLast": "lambda.amazonaws.com"
+                  }
+                }
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary


### PR DESCRIPTION
## Proposed changes
### What changed
- In the VPC policy in the Lambda roles, add a `Condition` to enforce that permission is only granted if the request is made via Lambda service.

### Why did it change
- To restrict permissions and fix security hotspot.

<img width="1424" height="748" alt="image" src="https://github.com/user-attachments/assets/8e684682-cd64-4111-954d-0613caf8daf1" />


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
