### PR TITLE
docs: Ignore Math.random() security issue with NOSONAR 

### DIFF
--- a/src/functions/issueHandler.ts
+++ b/src/functions/issueHandler.ts
@@ -73,8 +73,7 @@ function getRandomConfig(): Configuration {
     },
   ];
 
-  // NOSONAR: Using Math.random() is safe here as security-critical randomness is not required
-  return configurations[Math.floor(Math.random() * configurations.length)];
+  return configurations[Math.floor(Math.random() * configurations.length)]; // NOSONAR: Using Math.random() is safe here as security-critical randomness is not required
 }
 
 export async function createToken(


### PR DESCRIPTION
## Proposed changes
### What changed
- Move `NOSONAR` comment next to problem line containing `Math.random()`

### Why did it change
- So that sonar ignores this as it's not a security hotspot

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXXX)

## Testing

BEFORE
<img width="1629" height="756" alt="Screenshot 2025-08-27 at 19 10 39" src="https://github.com/user-attachments/assets/59a10dee-4954-4490-ab23-fda8a1445553" />


AFTER
<img width="1629" height="756" alt="Screenshot 2025-08-27 at 19 11 13" src="https://github.com/user-attachments/assets/15a19f6d-afaf-4f89-a717-574cad1bc6a9" />


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
