### PR TITLE
fix: correct path to status list object in S3 bucket

### DIFF
--- a/src/functions/issueHandler.ts
+++ b/src/functions/issueHandler.ts
@@ -32,8 +32,8 @@ export async function handler(
   const config = getConfig(process.env, REQUIRED_ENV_VARS);
 
   const configuration = getRandomConfig();
-  const objectKey = randomUUID();
-  const uri = `${config.SELF_URL}/t/${objectKey}`;
+  const objectKey = "t/" + randomUUID();
+  const uri = `${config.SELF_URL}/${objectKey}`;
   const token = await createToken(
     configuration.statusList,
     uri,

--- a/src/functions/revokeHandler.ts
+++ b/src/functions/revokeHandler.ts
@@ -26,7 +26,8 @@ export async function handler(
 
   const { body } = event;
   const { uri, idx } = extractUriAndIndex(body);
-  const objectKey = uri.substring(uri.lastIndexOf("/") + 1);
+  const url = new URL(uri);
+  const objectKey = url.pathname.slice(1);
   const updatedToken = await createToken(
     getRevokedConfiguration(idx),
     uri,

--- a/test/functions/issueHandler.test.ts
+++ b/test/functions/issueHandler.test.ts
@@ -55,7 +55,7 @@ describe("handler", () => {
     expect(derToJose).toHaveBeenCalledWith("AQID", "ES256");
     expect(putObject).toHaveBeenCalledWith(
       "test-bucket-name",
-      "36940190-e6af-42d0-9181-74c944dc4af7",
+      "t/36940190-e6af-42d0-9181-74c944dc4af7",
       "eyJhbGciOiJFUzI1NiIsImtpZCI6InRlc3Qta2V5LWlkIiwidHlwIjoic3RhdHVzbGlzdCtqd3QifQ.eyJpYXQiOjE3NTU3MzQ0MDAsImV4cCI6MTc1ODMyNjQwMCwic3RhdHVzX2xpc3QiOnsiYml0cyI6MiwibHN0IjoiZU5wemNBRUFBTVlBaFEifSwic3ViIjoiaHR0cHM6Ly90ZXN0LXN0YXR1cy1saXN0LmNvbS90LzM2OTQwMTkwLWU2YWYtNDJkMC05MTgxLTc0Yzk0NGRjNGFmNyIsInR0bCI6MjU5MjAwMH0.mockJoseSignature",
     );
     expect(logger.addContext).toHaveBeenCalledWith(mockContext);

--- a/test/functions/revokeHandler.test.ts
+++ b/test/functions/revokeHandler.test.ts
@@ -57,7 +57,7 @@ describe("handler", () => {
 
     expect(putObject).toHaveBeenCalledWith(
       "test-bucket-name",
-      "36940190-e6af-42d0-9181-74c944dc4af7",
+      "t/36940190-e6af-42d0-9181-74c944dc4af7",
       "eyJhbGciOiJFUzI1NiIsImtpZCI6InRlc3Qta2V5LWlkIiwidHlwIjoic3RhdHVzbGlzdCtqd3QifQ.eyJpYXQiOjEyMzQ1Njc4OTAsImV4cCI6MTIzNzE1OTg5MCwic3RhdHVzX2xpc3QiOnsiYml0cyI6MiwibHN0IjoiZU5xVFN3Y0FBS1VBaGcifSwic3ViIjoiaHR0cHM6Ly90ZXN0LXN0YXR1cy1saXN0LmNvbS90LzM2OTQwMTkwLWU2YWYtNDJkMC05MTgxLTc0Yzk0NGRjNGFmNyIsInR0bCI6MjU5MjAwMH0.mockJoseSignature",
     );
     expect(logger.addContext).toHaveBeenCalledWith(mockContext);


### PR DESCRIPTION
## Proposed changes
### What changed
- Add the `t/` prefix to the S3 object key so that objects are correctly stored under the `t/` folder in S3 status list bucket.

### Why did it change
The S3 object key was being generated without the folder prefix, causing objects to be stored in the root of the bucket instead of the intended `t/` folder structure. This was causing an error when retrieving the object from the bucket by its URI, as API Gateway proxies requests with the `t/` path but the objects were stored without the prefix in S3.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXXX)

## Testing
Deployed to the development environment. 

**Issue flow**
<img width="1231" height="1125" alt="Screenshot 2025-09-11 at 20 38 41" src="https://github.com/user-attachments/assets/f388a071-8c8f-4ad0-853a-b58b735e5547" />

<img width="1189" height="246" alt="Screenshot 2025-09-11 at 20 39 15" src="https://github.com/user-attachments/assets/d67f4af9-8de0-4141-afbe-e52ee8e7969c" />


**Revoke flow**

Same object URI but slightly different token after triggering the revoke function.

<img width="1226" height="1089" alt="Screenshot 2025-09-11 at 20 44 32" src="https://github.com/user-attachments/assets/3808f897-3831-4d27-8632-6658feb284cf" />

<img width="1105" height="246" alt="Screenshot 2025-09-11 at 20 44 12" src="https://github.com/user-attachments/assets/7cf51dca-94f9-4021-b3e4-10c77c6d9ceb" />


## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
