### PR TITLE
chore: remove NOSONAR comment

### DIFF
--- a/src/functions/issueHandler.ts
+++ b/src/functions/issueHandler.ts
@@ -65,5 +65,5 @@ function getRandomConfig(): Configuration {
     },
   ];
 
-  return configurations[Math.floor(Math.random() * configurations.length)]; // NOSONAR: Using Math.random() is safe here as security-critical randomness is not require
+  return configurations[Math.floor(Math.random() * configurations.length)];
 }


### PR DESCRIPTION
## Proposed changes
### What changed
- Remove `NOSONAR` comment that ignores a security hotspot.

### Why did it change
- This is a safe security hotspot - using `Math.random()` is safe in this case as security-critical randomness is not require; however, instead of ignoring the issue with `NOSONAR`, we should ask a security architect to mark the issue as safe in SonarCloud.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
