### PR TITLE
chore: throw new Error() instead of Error() to fix code smell

### DIFF
--- a/src/common/aws/kms.ts
+++ b/src/common/aws/kms.ts
@@ -37,7 +37,7 @@ export async function sign(
   const response = await kmsClient.send(command);
 
   if (!response.Signature) {
-    throw Error("No Signature returned");
+    throw new Error("No Signature returned");
   }
 
   return response.Signature;


### PR DESCRIPTION
## Proposed changes
### What changed
- Throw `new Error()` instead of `Error()`.

### Why did it change
To fix code smell in the main branch:

<img width="1710" height="945" alt="image" src="https://github.com/user-attachments/assets/a807b4c7-9757-46a7-9fef-107d103b4c79" />


### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
