### PR TITLE
ci: skip SonarQube Scan step for Dependabot-triggered workflows

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -55,6 +55,7 @@ jobs:
         run: sam build --parallel
 
       - name: SonarQube Scan
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Proposed changes
### What changed
- Add a condition (`if: ${{ github.actor != 'dependabot[bot]' }}`) to prevent the SonarQube Scan step in the CI workflow from executing when the workflow is triggered by Dependabot. The step will still run when actors other than Dependabot push to the same branch.

### Why did it change
- Dependabot does not have access to the `SONAR_TOKEN` required for the SonarQube Scan step, causing workflow failures. This change avoids those failures by skipping the step for Dependabot-triggered runs.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
